### PR TITLE
chore: roll back .NET, update renovate config

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.1.24452.12",
+    "version": "8.0.402",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,34 +1,34 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommits"
   ],
   "prHourlyLimit": 2,
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "*"
-      ],
       "groupName": "all dependencies",
       "groupSlug": "all-deps",
-      "automerge": true
-    },
-    {
-      "matchPackagePrefixes": [
-        "dotnet-sdk"
+      "automerge": true,
+      "matchPackageNames": [
+        "*"
       ]
     },
     {
-      "matchPackagePrefixes": [
-        "GodotSharp",
-        "Godot.NET.Sdk"
+      "matchPackageNames": [
+        "dotnet-sdk{/,}**"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "GodotSharp{/,}**",
+        "Godot.NET.Sdk{/,}**"
       ],
       "allowedVersions": "/^$/"
     },
     {
-      "matchPackagePrefixes": [
-        "Chickensoft"
+      "matchPackageNames": [
+        "Chickensoft{/,}**"
       ],
       "allowedVersions": "/^(\\d+\\.\\d+\\.\\d+)(-godot(\\d+\\.)+\\d+(-.*)?)?$/"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     ":semanticCommits"
   ],
   "prHourlyLimit": 2,
-  "versioning": "loose",
   "packageRules": [
     {
       "matchPackagePatterns": [
@@ -13,14 +12,12 @@
       ],
       "groupName": "all dependencies",
       "groupSlug": "all-deps",
-      "automerge": true,
-      "allowedVersions": "!/preview/"
+      "automerge": true
     },
     {
       "matchPackagePrefixes": [
         "dotnet-sdk"
-      ],
-      "allowedVersions": "!/preview/"
+      ]
     },
     {
       "matchPackagePrefixes": [


### PR DESCRIPTION
* Rolled back .NET to v8
* Updated renovate config to no longer specify "loose" versioning, which seems to prevent attempts to update to preview versions of dependences in local dry runs.
  * This change applies across all dependencies; we should be able to specify loose versioning for specific deps if needed in future (e.g., preview/RC versions of GodotSharp).
* Removed handwritten rules for avoiding preview versions on individual dependencies, which seem to be unnecessary when not using "loose" versioning globally.
* Migrations of renovate config suggested by renovate debug output on a local dry run:
  * Extend the "recommended" config instead of the "base" config
  * Use "matchPackageNames" instead of "matchPackagePatterns"
  * Use "matchPackageNames" with patterns instead of "matchPackagePrefixes"