### PR TITLE
doc: recommend treating CS9057 as error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -144,7 +144,6 @@
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableMsBuildLoadProjectsOnDemand": false,
   "omnisharp.maxFindSymbolsItems": 3000,
-  "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.useModernNet": true,
   // Remove these if you're happy with your terminal profiles.
   "terminal.integrated.defaultProfile.windows": "Git Bash",
@@ -164,5 +163,6 @@
       "icon": "terminal-powershell",
       "source": "PowerShell"
     }
-  }
+  },
+  "dotnet.formatting.organizeImportsOnFormat": true
 }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ Make sure you get the latest versions of the packages here on nuget: [Chickensof
 ```
 
 > [!WARNING]
+> We strongly recommend treating warning `CS9057` as an error to catch possible compiler-mismatch issues with the Introspection generator. (See the [Introspection] README for more details.) To do so, add a `WarningsAsErrors` line to your `.csproj` file's `PropertyGroup`:
+>
+> ```xml
+> <PropertyGroup>
+>   <TargetFramework>net8.0</TargetFramework>
+>   ...
+>   <!-- Catch compiler-mismatch issues with the Introspection generator -->
+>   <WarningsAsErrors>CS9057</WarningsAsErrors>
+>   ...
+> </PropertyGroup>
+> ```
+
+> [!WARNING]
 > Don't forget the `PrivateAssets="all" OutputItemType="analyzer"` when including a source generator package in your project.
 
 ## 💾 Serializable Types
@@ -155,7 +168,7 @@ public partial class Model {
   public required string Name { get; init; } // required allows it to be non-nullable
 
   [Save("description")]
-  public string? Description { get; init; } // not required, should be nullable 
+  public string? Description { get; init; } // not required, should be nullable
 }
 ```
 
@@ -189,7 +202,7 @@ public partial class Doctor : Person {
 [Meta, Id("lawyer")]
 public partial class Lawyer : Person {
   [Save("cases_won")]
-  public required int CasesWon { get; init; }  
+  public required int CasesWon { get; init; }
 }
 ```
 
@@ -343,7 +356,7 @@ var options = new JsonSerializerOptions {
     // Vanilla System.Text.Json context that has the enum registered
     ModelWithEnumContext.Default,
     // Chickensoft type resolver
-    new SerializableTypeResolver() 
+    new SerializableTypeResolver()
   ),
   Converters = {
     // You'll need to specify a converter for your enum — there's also


### PR DESCRIPTION
CS9057 is a compiler warning issued when a consuming project is using an earlier version of the .NET compiler than was used to compile the Introspection generator. Such a mismatch can have serious, hard-to-diagnose downstream consequences for users. (See chickensoft-games/Introspection#20 and chickensoft-games/GameDemo#104.) This change updates the documentation to recommend treating CS9057 as an error in consuming projects, to make those issues easier to diagnose and fix.

Additionally, this change updates a VSCode setting to reflect new naming.